### PR TITLE
frontend/backend: modify transaction loading flow and add fiat value at time of transaction

### DIFF
--- a/frontends/web/src/api/account.ts
+++ b/frontends/web/src/api/account.ts
@@ -134,7 +134,7 @@ export type Conversions = null | {
 
 export interface IAmount {
     amount: string;
-    conversions: Conversions;
+    conversions?: Conversions;
     unit: Coin;
 }
 
@@ -151,6 +151,7 @@ export const getBalance = (code: AccountCode): Promise<IBalance> => {
 export interface ITransaction {
     addresses: string[];
     amount: IAmount;
+    amountAtTime: IAmount;
     fee: IAmount;
     feeRatePerKb: IAmount;
     gas: number;
@@ -184,6 +185,9 @@ export const getTransactionList = (code: AccountCode): Promise<ITransaction[]> =
   return apiGet(`account/${code}/transactions`);
 };
 
+export const getTransaction = (code: AccountCode, id: ITransaction['txID']): Promise<ITransaction> => {
+  return apiGet(`account/${code}/transaction?id=${id}`);
+};
 
 export interface IExport {
     success: boolean;

--- a/frontends/web/src/components/rates/rates.tsx
+++ b/frontends/web/src/components/rates/rates.tsx
@@ -16,7 +16,7 @@
  */
 
 import { PropsWithChildren } from 'react';
-import { Coin, Fiat } from '../../api/account';
+import { Coin, Fiat, IAmount } from '../../api/account';
 import { share } from '../../decorators/share';
 import { Store } from '../../decorators/store';
 import { setConfig } from '../../utils/config';
@@ -118,13 +118,8 @@ export function formatCurrency(amount: number, fiat: Fiat): string {
 
 }
 
-export interface AmountInterface {
-    amount: string;
-    unit: Coin;
-}
-
 interface ProvidedProps {
-    amount: AmountInterface;
+    amount: IAmount;
     tableRow?: boolean;
     unstyled?: boolean;
     skipUnit?: boolean;
@@ -143,13 +138,19 @@ function Conversion({
   noAction,
   children,
 }: PropsWithChildren<Props>): JSX.Element | null {
-  if (!rates) {
-    return null;
-  }
+
   const coin = amount.unit;
-  let formattedValue = '';
-  if (rates[coin]) {
-    formattedValue = formatCurrency(rates[coin][active] * Number(amount.amount), active);
+  let formattedValue = '---';
+
+  if (amount.conversions) {
+    if (amount.conversions[active] !== '')
+      formattedValue = amount.conversions[active];
+  } else {
+    if (rates && rates[coin]) {
+      // TODO This solution is not the best: it is better to have the backend calculating the value,
+      // with better precision, using coins/convertToFiat endpoint
+      formattedValue = formatCurrency(rates[coin][active] * Number(amount.amount), active);
+    }
   }
   if (tableRow) {
     return (

--- a/frontends/web/src/components/transactions/transaction.tsx
+++ b/frontends/web/src/components/transactions/transaction.tsx
@@ -33,6 +33,7 @@ interface State {
     transactionDialog: boolean;
     newNote: string;
     editMode: boolean;
+    transactionInfo?: accountApi.ITransaction;
 }
 
 interface TransactionProps extends accountApi.ITransaction {
@@ -63,10 +64,13 @@ class Transaction extends Component<Props, State> {
   };
 
   private showDetails = () => {
-    this.setState({
-      transactionDialog: true,
-      newNote: this.props.note,
-      editMode: !this.props.note,
+    accountApi.getTransaction(this.props.accountCode, this.props.internalID).then(transaction => {
+      this.setState({
+        transactionInfo: transaction,
+        transactionDialog: true,
+        newNote: this.props.note,
+        editMode: !this.props.note,
+      });
     });
   };
 
@@ -111,15 +115,8 @@ class Transaction extends Component<Props, State> {
       index,
       explorerURL,
       type,
-      txID,
       amount,
-      fee,
       feeRatePerKb,
-      gas,
-      nonce,
-      vsize,
-      size,
-      weight,
       numConfirmations,
       numConfirmationsComplete,
       time,
@@ -131,6 +128,7 @@ class Transaction extends Component<Props, State> {
       transactionDialog,
       newNote,
       editMode,
+      transactionInfo,
     } = this.state;
     const arrow = type === 'receive' ? (
       <ArrowIn />
@@ -219,7 +217,9 @@ class Transaction extends Component<Props, State> {
           </div>
         </div>
         {
-          transactionDialog && (
+          transactionDialog && transactionInfo && (
+            // Amount and Confirmations info are displayed using props data instead of transactionInfo
+            // because they are live updated
             <Dialog title="Transaction Details" onClose={this.hideDetails} slim medium>
               <form onSubmit={this.handleEdit} className={style.detailInput}>
                 <label htmlFor="note">{t('note.title')}</label>
@@ -284,23 +284,31 @@ class Transaction extends Component<Props, State> {
                 </p>
               </div>
               <div className={style.detail}>
+                <label>{t('transaction.details.fiatAtTime')}</label>
+                <p>
+                  <span className={`${style.fiat} ${typeClassName}`}>
+                    <FiatConversion amount={transactionInfo.amountAtTime} noAction>{sign}</FiatConversion>
+                  </span>
+                </p>
+              </div>
+              <div className={style.detail}>
                 <label>{t('transaction.details.amount')}</label>
                 <p>
                   <span className={`${style.currency} ${typeClassName}`}>
-                    {sign}{amount.amount}
+                    {sign}{transactionInfo.amount.amount}
                     {' '}
-                    <span className={style.currencyUnit}>{amount.unit}</span>
+                    <span className={style.currencyUnit}>{transactionInfo.amount.unit}</span>
                   </span>
                 </p>
               </div>
               <div className={style.detail}>
                 <label>{t('transaction.fee')}</label>
                 {
-                  fee && fee.amount ? (
+                  transactionInfo.fee && transactionInfo.fee.amount ? (
                     <p title={feeRatePerKb.amount ? feeRatePerKb.amount + ' ' + feeRatePerKb.unit + '/Kb' : ''}>
-                      {fee.amount}
+                      {transactionInfo.fee.amount}
                       {' '}
-                      <span className={style.currencyUnit}>{fee.unit}</span>
+                      <span className={style.currencyUnit}>{transactionInfo.fee.unit}</span>
                     </p>
                   ) : (
                     <p>---</p>
@@ -310,7 +318,7 @@ class Transaction extends Component<Props, State> {
               <div className={[style.detail, style.addresses].join(' ')}>
                 <label>{t('transaction.details.address')}</label>
                 <div className={style.detailAddresses}>
-                  { addresses.map((address) => (
+                  { transactionInfo.addresses.map((address) => (
                     <CopyableInput
                       key={address}
                       alignRight
@@ -322,27 +330,27 @@ class Transaction extends Component<Props, State> {
                 </div>
               </div>
               {
-                gas ? (
+                transactionInfo.gas ? (
                   <div className={style.detail}>
                     <label>{t('transaction.gas')}</label>
-                    <p>{gas}</p>
+                    <p>{transactionInfo.gas}</p>
                   </div>
                 ) : null
               }
               {
-                nonce !== null ? (
+                transactionInfo.nonce !== null ? (
                   <div className={style.detail}>
                     <label>Nonce</label>
-                    <p>{nonce}</p>
+                    <p>{transactionInfo.nonce}</p>
                   </div>
                 ) : null
               }
               {
-                weight ? (
+                transactionInfo.weight ? (
                   <div className={style.detail}>
                     <label>{t('transaction.weight')}</label>
                     <p>
-                      {weight}
+                      {transactionInfo.weight}
                       {' '}
                       <span className={style.currencyUnit}>WU</span>
                     </p>
@@ -350,11 +358,11 @@ class Transaction extends Component<Props, State> {
                 ) : null
               }
               {
-                vsize ? (
+                transactionInfo.vsize ? (
                   <div className={style.detail}>
                     <label>{t('transaction.vsize')}</label>
                     <p>
-                      {vsize}
+                      {transactionInfo.vsize}
                       {' '}
                       <span className={style.currencyUnit}>b</span>
                     </p>
@@ -362,11 +370,11 @@ class Transaction extends Component<Props, State> {
                 ) : null
               }
               {
-                size ? (
+                transactionInfo.size ? (
                   <div className={style.detail}>
                     <label>{t('transaction.size')}</label>
                     <p>
-                      {size}
+                      {transactionInfo.size}
                       {' '}
                       <span className={style.currencyUnit}>b</span>
                     </p>
@@ -381,15 +389,15 @@ class Transaction extends Component<Props, State> {
                     borderLess
                     flexibleHeight
                     className={style.detailAddress}
-                    value={txID} />
+                    value={transactionInfo.txID} />
                 </div>
               </div>
               <div className={[style.detail, 'flex-center'].join(' ')}>
                 <p>
                   <A
                     className={style.externalLink}
-                    href={explorerURL + txID}
-                    title={t('transaction.explorerTitle') + '\n' + explorerURL + txID}>
+                    href={explorerURL + transactionInfo.txID}
+                    title={t('transaction.explorerTitle') + '\n' + explorerURL + transactionInfo.txID}>
                     {t('transaction.explorerTitle')}
                   </A>
                 </p>

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -1320,6 +1320,7 @@
       "amount": "Amount",
       "date": "Date",
       "fiat": "Fiat",
+      "fiatAtTime": "Fiat at time of transaction",
       "fiatAmount": "Fiat amount",
       "status": "Status",
       "type": "Type"

--- a/frontends/web/src/locales/it/app.json
+++ b/frontends/web/src/locales/it/app.json
@@ -1173,6 +1173,7 @@
       "amount": "Importo",
       "date": "Data",
       "fiat": "Fiat",
+      "fiatAtTime": "Fiat al tempo della transazione",
       "fiatAmount": "Importo fiat",
       "status": "Status",
       "type": "Tipo"


### PR DESCRIPTION
/transactions endpoint modified to load only data displayed in transactionfrontend list

A new /transaction endpoint created to load all available data for specific transactionin order to populate the detailed transaction view in frontend

FiatConversion component modified to use backend-calculated fiat amount conversionswhen available

Added code to show fiat value at time of transaction in detailed transaction view