### PR TITLE
frontend: updates chart data is older than expected message

### DIFF
--- a/backend/rates/history.go
+++ b/backend/rates/history.go
@@ -213,20 +213,26 @@ func (updater *RateUpdater) HistoryEarliestTimestamp(coin, fiat string) time.Tim
 	return t
 }
 
-// HistoryLatestTimestampAll returns the latest timestamp for which there an exchange rates is
-// available for all coins. In other words: the earliest of all latest timestamps.
-func (updater *RateUpdater) HistoryLatestTimestampAll(coins []string, fiat string) time.Time {
+// HistoryLatestTimestampAll returns:
+// @1: the latest timestamp for which an exchange rates is available for all coins.
+// In other words: the earliest of all latest timestamps.
+// @2: a map that associates each coin/fiat pair to the latest timestamp available
+// for that exchange rate.
+func (updater *RateUpdater) HistoryLatestTimestampAll(coins []string, fiat string) (time.Time, map[string]time.Time) {
 	var result time.Time
+	timestamps := make(map[string]time.Time)
 	for _, coin := range coins {
-		latest := updater.HistoryLatestTimestamp(coin, fiat)
-		if latest.IsZero() {
-			return latest
+		timestamps[coin] = updater.HistoryLatestTimestamp(coin, fiat)
+	}
+	for _, timestamp := range timestamps {
+		if timestamp.IsZero() {
+			return timestamp, timestamps
 		}
-		if result.IsZero() || latest.Before(result) {
-			result = latest
+		if result.IsZero() || timestamp.Before(result) {
+			result = timestamp
 		}
 	}
-	return result
+	return result, timestamps
 }
 
 type fetchTimeRange struct {

--- a/backend/rates/history_test.go
+++ b/backend/rates/history_test.go
@@ -153,12 +153,17 @@ func TestHistoryEarliestLatest(t *testing.T) {
 	assert.Zero(t, updater.HistoryEarliestTimestamp("foo", "bar"), "zero earliest")
 	assert.Zero(t, updater.HistoryLatestTimestamp("foo", "bar"), "zero latest")
 
-	assert.Equal(t,
-		updater.history["ltcUSD"][1].timestamp,
-		updater.HistoryLatestTimestampAll([]string{"btc", "ltc"}, "USD"))
+	earliest, timestamps := updater.HistoryLatestTimestampAll([]string{"btc", "ltc"}, "USD")
+	assert.Equal(t, updater.history["ltcUSD"][1].timestamp, earliest)
+	assert.Equal(t, updater.history["ltcUSD"][1].timestamp, timestamps["ltc"])
+	assert.Equal(t, updater.history["btcUSD"][3].timestamp, timestamps["btc"])
 
-	assert.Zero(t, updater.HistoryLatestTimestampAll([]string{"btc", "foo"}, "USD"))
-	assert.Zero(t, updater.HistoryLatestTimestampAll([]string{"foo", "btc"}, "USD"))
+	earliest, timestamps = updater.HistoryLatestTimestampAll([]string{"btc", "foo"}, "USD")
+	assert.Zero(t, earliest)
+	assert.Equal(t, updater.history["btcUSD"][3].timestamp, timestamps["btc"])
+	earliest, timestamps = updater.HistoryLatestTimestampAll([]string{"foo", "btc"}, "USD")
+	assert.Zero(t, earliest)
+	assert.Equal(t, updater.history["btcUSD"][3].timestamp, timestamps["btc"])
 }
 
 // TestLoadDumpUnusableDB ensures no panic when the RateUpdater.historyDB is unusable.

--- a/frontends/web/src/api/account.ts
+++ b/frontends/web/src/api/account.ts
@@ -124,6 +124,7 @@ export interface ISummary {
     chartTotal: number | null;
     formattedChartTotal: string | null;
     chartIsUpToDate: boolean; // only valid if chartDataMissing is false
+    ratesTimestamps?: { [key in CoinCode]: number };
 }
 
 export const getSummary = (): Promise<ISummary> => {

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -445,13 +445,15 @@
   },
   "chart": {
     "dataMissing": "Gathering historical data... stay tuned.",
+    "dataOutOfDate": "Chart data can be out of date:",
     "dataUpdating": "updating data…",
     "filter": {
       "all": "All",
       "month": "Month",
       "week": "Week",
       "year": "Year"
-    }
+    },
+    "lastDatapoint": "last datapoint available at "
   },
   "checkSDcard": "checking microSD card",
   "clickHere": "Click here.",

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -445,7 +445,8 @@
   },
   "chart": {
     "dataMissing": "Gathering historical data... stay tuned.",
-    "dataOutOfDate": "Chart data can be out of date:",
+    "dataOldTimestamps_one": "Exchange rates for {{name}} is older than expected. Last updated {{timeAgo}}",
+    "dataOldTimestamps_other": "Exchange rates for {{name}} are older than expected. Last updated {{timeAgo}}",
     "dataUpdating": "updating data…",
     "filter": {
       "all": "All",
@@ -579,6 +580,7 @@
     "appVersion": "App version:"
   },
   "generic": {
+    "and": "and",
     "enabled_false": "Disabled",
     "enabled_true": "Enabled"
   },

--- a/frontends/web/src/routes/account/summary/chart.module.css
+++ b/frontends/web/src/routes/account/summary/chart.module.css
@@ -14,23 +14,8 @@
   display: flex;
   flex-direction: column;
   justify-content: center;
+  padding: 0 var(--space-half);
   text-align: center;
-}
-
-.chartUpdatingMessage img {
-  max-height: 20px;
-  margin-right: .25rem;
-  vertical-align: text-bottom;
-}
-
-.chartUpdatingMessage div {
-  text-align: left;
-  margin-left: 1rem;
-  margin-right: 1rem;
-}
-
-.chartUpdatingMessage ul {
-  margin-top: .25rem;
 }
 
 .chart header {

--- a/frontends/web/src/routes/account/summary/chart.module.css
+++ b/frontends/web/src/routes/account/summary/chart.module.css
@@ -12,11 +12,26 @@
   align-items: center;
   color: var(--color-tertiary);
   display: flex;
-  flex-direction: row;
+  flex-direction: column;
   justify-content: center;
   text-align: center;
 }
 
+.chartUpdatingMessage img {
+  max-height: 20px;
+  margin-right: .25rem;
+  vertical-align: text-bottom;
+}
+
+.chartUpdatingMessage div {
+  text-align: left;
+  margin-left: 1rem;
+  margin-right: 1rem;
+}
+
+.chartUpdatingMessage ul {
+  margin-top: .25rem;
+}
 
 .chart header {
   display: flex;


### PR DESCRIPTION
Show which coins are not up-to-date, but hide fiat as on account summary only 1 fiat is used.

Show time-ago of the coin with the oldest conversion rate, so that user understand that the chart is a bit off.

Use Intl.RelativeTimeFormat api, which is relatively new but should be supported in chrome since v71.

cc @benma